### PR TITLE
Add API endpoint to control mock file watching

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -25,8 +25,8 @@ and saving their responses following the filename convention.
 
 ### Tests
 - Utilities are unit-tested.
-- Mockaton server is integration tested. Except for file watching, you could 
- write Mockaton in another language and run our test suite against it.
+- Mockaton server is integration tested. You could write Mockaton in another
+ language and run our test suite against it.
 - UI is pixel-diff tested with `pixaton`, which is a sister project of Puppeteer utilities.
 
 

--- a/src/client/ApiCommander.js
+++ b/src/client/ApiCommander.js
@@ -31,6 +31,9 @@ export class Commander {
 	setCorsAllowed = value => this.#patch(API.cors, value)
 
 	/** @returns {Promise<Response>} */
+	setWatchMocks = enabled => this.#patch(API.watchMocks, enabled)
+
+	/** @returns {Promise<Response>} */
 	setProxyFallback = proxyAddr => this.#patch(API.fallback, proxyAddr)
 
 	/** @returns {Promise<Response>} */

--- a/src/client/ApiConstants.js
+++ b/src/client/ApiConstants.js
@@ -23,6 +23,7 @@ export const API = {
 	throws: MOUNT + '/throws',
 	toggle500: MOUNT + '/toggle500',
 	watchHotReload: MOUNT + '/watch-hot-reload',
+	watchMocks: MOUNT + '/watch-mocks',
 }
 
 export const HEADER_502 = 'Mockaton502'

--- a/src/server/Api.js
+++ b/src/server/Api.js
@@ -10,7 +10,7 @@ import {
 	DASHBOARD_ASSETS,
 	CLIENT_DIR
 } from './WatcherDevClient.js'
-import { longPollClientSyncVersion } from './Watcher.js'
+import { longPollClientSyncVersion, startWatchers, stopWatchers } from './Watcher.js'
 
 import pkgJSON from '../../package.json' with { type: 'json' }
 
@@ -54,7 +54,9 @@ export const apiPatchReqs = new Map([
 	[API.toggle500, toggleRoute500],
 
 	[API.delayStatic, setStaticRouteIsDelayed],
-	[API.staticStatus, setStaticRouteStatusCode]
+	[API.staticStatus, setStaticRouteStatusCode],
+
+	[API.watchMocks, setWatchMocks]
 ])
 
 

--- a/src/server/Api.js
+++ b/src/server/Api.js
@@ -111,6 +111,21 @@ async function setCorsAllowed(req, response) {
 }
 
 
+async function setWatchMocks(req, response) {
+	const enabled = await req.json()
+
+	if (typeof enabled !== 'boolean')
+		response.unprocessable(`Expected boolean for "watchMocks"`)
+	else {
+		if (enabled)
+			startWatchers()
+		else
+			stopWatchers()
+		response.ok()
+	}
+}
+
+
 async function setGlobalDelay(req, response) {
 	const delay = await req.json()
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1140,7 +1140,7 @@ describe('Registering Mocks', () => {
 
 
 describe('Registering Static Mocks', () => {
-	before(watchStaticDir)
+	before(async () => await api.setWatchMocks(true))
 
 	const fx = new FixtureStatic('static-register.txt')
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1176,7 +1176,24 @@ describe('Registering Mocks', () => {
 
 
 describe('Registering Static Mocks', () => {
-	before(async () => await api.setWatchMocks(true))
+	const fxTest = new FixtureStatic('watcher-test-static.txt')
+	before(async () => {
+		// Verify watcher is not running - file write should not trigger registration
+		await fxTest.write()
+		await new Promise(resolve => setTimeout(resolve, 50))
+		let { staticBrokers } = await fetchState()
+		equal(staticBrokers['/' + fxTest.file], undefined, 'Watcher should not be running yet')
+
+		// Enable watchers
+		await api.setWatchMocks(true)
+
+		// Verify watcher is now running - file write should trigger registration
+		await fxTest.unlink()
+		await fxTest.register()
+		staticBrokers = (await fetchState()).staticBrokers
+		equal(staticBrokers['/' + fxTest.file].route, '/' + fxTest.file, 'Watcher should now be running')
+		await fxTest.unlink()
+	})
 
 	const fx = new FixtureStatic('static-register.txt')
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -17,7 +17,6 @@ import { readBody } from './utils/HttpIncomingMessage.js'
 import { CorsHeader } from './utils/http-cors.js'
 
 import { Mockaton } from './Mockaton.js'
-import { watchMocksDir, watchStaticDir } from './Watcher.js'
 
 import { Commander } from '../client/ApiCommander.js'
 import { parseFilename } from '../client/Filename.js'

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1073,30 +1073,20 @@ test('head for get. returns the headers without body only for GETs requested as 
 
 
 describe('Registering Mocks', () => {
-	const fxTest = new Fixture('watcher-test.GET.200.json')
-	before(async () => {
-		// Ensure watchers are stopped first
-		await api.setWatchMocks(false)
+	const fxA = new Fixture('register(default).GET.200.json')
+	const fxB = new Fixture('register(alt).GET.200.json')
 
-		// Verify watcher is not running - file write should not trigger registration
-		await fxTest.write()
+	test('enables watcher via API', async () => {
+		const fx = new Fixture('watcher-enable-test.GET.200.json')
+		await fx.write()
 		await new Promise(resolve => setTimeout(resolve, 50))
-		let b = await fxTest.fetchBroker()
-		equal(b, undefined, 'Watcher should not be running yet')
+		let b = await fx.fetchBroker()
+		equal(b, undefined, 'File should not be registered without watcher')
+		await fx.unlink()
 
 		// Enable watchers
 		await api.setWatchMocks(true)
-
-		// Verify watcher is now running - file write should trigger registration
-		await fxTest.unlink()
-		await fxTest.register()
-		b = await fxTest.fetchBroker()
-		equal(b.file, fxTest.file, 'Watcher should now be running')
-		await fxTest.unlink()
 	})
-
-	const fxA = new Fixture('register(default).GET.200.json')
-	const fxB = new Fixture('register(alt).GET.200.json')
 
 	test('register', async () => {
 		await fxA.register()

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -263,25 +263,6 @@ describe('CORS', () => {
 })
 
 
-describe('Watch Mocks', () => {
-	describe('Set Watch Mocks', () => {
-		test('422 for non boolean', async () => {
-			const r = await api.setWatchMocks('not-a-boolean')
-			equal(r.status, 422)
-			equal(await r.text(), 'Expected boolean for "watchMocks"')
-		})
-
-		test('200', async () => {
-			const r = await api.setWatchMocks(true)
-			equal(r.status, 200)
-
-			const r2 = await api.setWatchMocks(false)
-			equal(r2.status, 200)
-		})
-	})
-})
-
-
 describe('Dashboard', () => {
 	test('renders', async () => {
 		const r = await request(API.dashboard)
@@ -1072,23 +1053,34 @@ test('head for get. returns the headers without body only for GETs requested as 
 })
 
 
+describe('Watch mocks API toggler', () => {
+	test('422 for non boolean', async () => {
+		const r = await api.setWatchMocks('not-a-boolean')
+		equal(r.status, 422)
+		equal(await r.text(), 'Expected boolean for "watchMocks"')
+	})
+
+	test('200', async () => {
+		equal((await api.setWatchMocks(true)).status, 200)
+		equal((await api.setWatchMocks(false)).status, 200)
+	})
+})
+
 describe('Registering Mocks', () => {
 	const fxA = new Fixture('register(default).GET.200.json')
 	const fxB = new Fixture('register(alt).GET.200.json')
 
-	test('enables watcher via API', async () => {
-		const fx = new Fixture('watcher-enable-test.GET.200.json')
+	test('when watcher is off, newly added mocks do not get registered', async () => {
+		await api.setWatchMocks(false)
+		const fx = new Fixture('non-auto-registered-file.GET.200.json')
 		await fx.write()
-		await new Promise(resolve => setTimeout(resolve, 50))
-		let b = await fx.fetchBroker()
-		equal(b, undefined, 'File should not be registered without watcher')
+		await sleep()
+		equal(await fx.fetchBroker(), undefined)
 		await fx.unlink()
-
-		// Enable watchers
-		await api.setWatchMocks(true)
 	})
 
 	test('register', async () => {
+		await api.setWatchMocks(true)
 		await fxA.register()
 		await fxB.register()
 		const b = await fxA.fetchBroker()
@@ -1169,24 +1161,19 @@ describe('Registering Mocks', () => {
 
 
 describe('Registering Static Mocks', () => {
-	const fx = new FixtureStatic('static-register.txt')
-
-	test('enables watcher via API', async () => {
-		// Disable watchers first
+	test('when watcher is off, newly added mocks do not get registered', async () => {
 		await api.setWatchMocks(false)
-
-		const fxTest = new FixtureStatic('watcher-enable-test-static.txt')
-		await fxTest.write()
-		await new Promise(resolve => setTimeout(resolve, 50))
-		let { staticBrokers } = await fetchState()
-		equal(staticBrokers['/' + fxTest.file], undefined, 'File should not be registered without watcher')
-		await fxTest.unlink()
-
-		// Enable watchers
-		await api.setWatchMocks(true)
+		const fx = new FixtureStatic('non-auto-registered-file.txt')
+		await fx.write()
+		await sleep()
+		const { staticBrokers } = await fetchState()
+		equal(staticBrokers['/' + fx.file], undefined)
+		await fx.unlink()
 	})
 
+	const fx = new FixtureStatic('static-register.txt')
 	test('registers static', async () => {
+		await api.setWatchMocks(true)
 		await fx.register()
 		const { staticBrokers } = await fetchState()
 		deepEqual(staticBrokers, {
@@ -1244,3 +1231,8 @@ describe('Registering Static Mocks', () => {
 		})
 	})
 })
+
+
+async function sleep(ms = 100) {
+	await new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1181,6 +1181,9 @@ describe('Registering Mocks', () => {
 describe('Registering Static Mocks', () => {
 	const fxTest = new FixtureStatic('watcher-test-static.txt')
 	before(async () => {
+		// Ensure watchers are stopped first
+		await api.setWatchMocks(false)
+
 		// Verify watcher is not running - file write should not trigger registration
 		await fxTest.write()
 		await new Promise(resolve => setTimeout(resolve, 50))

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1054,7 +1054,7 @@ test('head for get. returns the headers without body only for GETs requested as 
 
 
 describe('Registering Mocks', () => {
-	before(watchMocksDir)
+	before(async () => await api.setWatchMocks(true))
 
 	const fxA = new Fixture('register(default).GET.200.json')
 	const fxB = new Fixture('register(alt).GET.200.json')

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1169,29 +1169,19 @@ describe('Registering Mocks', () => {
 
 
 describe('Registering Static Mocks', () => {
-	const fxTest = new FixtureStatic('watcher-test-static.txt')
-	before(async () => {
-		// Ensure watchers are stopped first
-		await api.setWatchMocks(false)
+	const fx = new FixtureStatic('static-register.txt')
 
-		// Verify watcher is not running - file write should not trigger registration
+	test('enables watcher via API', async () => {
+		const fxTest = new FixtureStatic('watcher-enable-test-static.txt')
 		await fxTest.write()
 		await new Promise(resolve => setTimeout(resolve, 50))
 		let { staticBrokers } = await fetchState()
-		equal(staticBrokers['/' + fxTest.file], undefined, 'Watcher should not be running yet')
+		equal(staticBrokers['/' + fxTest.file], undefined, 'File should not be registered without watcher')
+		await fxTest.unlink()
 
 		// Enable watchers
 		await api.setWatchMocks(true)
-
-		// Verify watcher is now running - file write should trigger registration
-		await fxTest.unlink()
-		await fxTest.register()
-		staticBrokers = (await fetchState()).staticBrokers
-		equal(staticBrokers['/' + fxTest.file].route, '/' + fxTest.file, 'Watcher should now be running')
-		await fxTest.unlink()
 	})
-
-	const fx = new FixtureStatic('static-register.txt')
 
 	test('registers static', async () => {
 		await fx.register()

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1172,6 +1172,9 @@ describe('Registering Static Mocks', () => {
 	const fx = new FixtureStatic('static-register.txt')
 
 	test('enables watcher via API', async () => {
+		// Disable watchers first
+		await api.setWatchMocks(false)
+
 		const fxTest = new FixtureStatic('watcher-enable-test-static.txt')
 		await fxTest.write()
 		await new Promise(resolve => setTimeout(resolve, 50))

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -263,6 +263,25 @@ describe('CORS', () => {
 })
 
 
+describe('Watch Mocks', () => {
+	describe('Set Watch Mocks', () => {
+		test('422 for non boolean', async () => {
+			const r = await api.setWatchMocks('not-a-boolean')
+			equal(r.status, 422)
+			equal(await r.text(), 'Expected boolean for "watchMocks"')
+		})
+
+		test('200', async () => {
+			const r = await api.setWatchMocks(true)
+			equal(r.status, 200)
+
+			const r2 = await api.setWatchMocks(false)
+			equal(r2.status, 200)
+		})
+	})
+})
+
+
 describe('Dashboard', () => {
 	test('renders', async () => {
 		const r = await request(API.dashboard)

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1075,6 +1075,9 @@ test('head for get. returns the headers without body only for GETs requested as 
 describe('Registering Mocks', () => {
 	const fxTest = new Fixture('watcher-test.GET.200.json')
 	before(async () => {
+		// Ensure watchers are stopped first
+		await api.setWatchMocks(false)
+
 		// Verify watcher is not running - file write should not trigger registration
 		await fxTest.write()
 		await new Promise(resolve => setTimeout(resolve, 50))

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1073,7 +1073,24 @@ test('head for get. returns the headers without body only for GETs requested as 
 
 
 describe('Registering Mocks', () => {
-	before(async () => await api.setWatchMocks(true))
+	const fxTest = new Fixture('watcher-test.GET.200.json')
+	before(async () => {
+		// Verify watcher is not running - file write should not trigger registration
+		await fxTest.write()
+		await new Promise(resolve => setTimeout(resolve, 50))
+		let b = await fxTest.fetchBroker()
+		equal(b, undefined, 'Watcher should not be running yet')
+
+		// Enable watchers
+		await api.setWatchMocks(true)
+
+		// Verify watcher is now running - file write should trigger registration
+		await fxTest.unlink()
+		await fxTest.register()
+		b = await fxTest.fetchBroker()
+		equal(b.file, fxTest.file, 'Watcher should now be running')
+		await fxTest.unlink()
+	})
 
 	const fxA = new Fixture('register(default).GET.200.json')
 	const fxB = new Fixture('register(alt).GET.200.json')

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -73,14 +73,11 @@ export function watchMocksDir() {
 
 
 export function watchStaticDir() {
-	if (staticWatcher)
-		return
-
 	const dir = config.staticDir
 	if (!dir)
 		return
 
-	staticWatcher = watch(dir, { recursive: true, persistent: false }, (_, file) => {
+	staticWatcher = staticWatcher || watch(dir, { recursive: true, persistent: false }, (_, file) => {
 		if (!file)
 			return
 

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -123,3 +123,16 @@ export function longPollClientSyncVersion(req, response) {
 	})
 	uiSyncVersion.subscribe(onARR)
 }
+
+
+export function startWatchers() {
+	watchMocksDir()
+	watchStaticDir()
+}
+
+export function stopWatchers() {
+	mocksWatcher?.close()
+	staticWatcher?.close()
+	mocksWatcher = null
+	staticWatcher = null
+}

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -76,11 +76,14 @@ export function watchMocksDir() {
 
 
 export function watchStaticDir() {
+	if (staticWatcher)
+		return
+
 	const dir = config.staticDir
 	if (!dir)
 		return
 
-	watch(dir, { recursive: true, persistent: false }, (_, file) => {
+	staticWatcher = watch(dir, { recursive: true, persistent: false }, (_, file) => {
 		if (!file)
 			return
 

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -14,6 +14,10 @@ import * as staticCollection from './staticCollection.js'
 import * as mockBrokerCollection from './mockBrokersCollection.js'
 
 
+let mocksWatcher = null
+let staticWatcher = null
+
+
 /**
  * ARR Event = Add, Remove, or Rename Mock
  *

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -50,11 +50,8 @@ const uiSyncVersion = new class extends EventEmitter {
 
 
 export function watchMocksDir() {
-	if (mocksWatcher)
-		return
-
 	const dir = config.mocksDir
-	mocksWatcher = watch(dir, { recursive: true, persistent: false }, (_, file) => {
+	mocksWatcher = mocksWatcher || watch(dir, { recursive: true, persistent: false }, (_, file) => {
 		if (!file)
 			return
 

--- a/src/server/Watcher.js
+++ b/src/server/Watcher.js
@@ -50,8 +50,11 @@ const uiSyncVersion = new class extends EventEmitter {
 
 
 export function watchMocksDir() {
+	if (mocksWatcher)
+		return
+
 	const dir = config.mocksDir
-	watch(dir, { recursive: true, persistent: false }, (_, file) => {
+	mocksWatcher = watch(dir, { recursive: true, persistent: false }, (_, file) => {
 		if (!file)
 			return
 

--- a/www/packed-sizes.json
+++ b/www/packed-sizes.json
@@ -1,61 +1,61 @@
 {
 	"/alternatives.html": {
-		"hash": "0YIyDddy1OUSB6n_GjZ0tZ8In9Y",
+		"hash": "CH1ycXWQ1lYg1wKNJbTuhzvGego",
 		"delta": 0,
 		"size": 20783
 	},
 	"/api.html": {
-		"hash": "oB0wl7NCoj9_vSW8D5fDqEAXJCQ",
-		"delta": 0,
-		"size": 39596
+		"hash": "LTDLfrQzI1iDqX8JyfBXkZ-d-Kg",
+		"delta": 1094,
+		"size": 40690
 	},
 	"/changelog.html": {
-		"hash": "0JGszM2JQnociP_MC39dtGAeFG4",
+		"hash": "z_Yhgu5xIRyoFqLlqcgDFJqTvKM",
 		"delta": 0,
 		"size": 28478
 	},
 	"/config.html": {
-		"hash": "htvggBpdo1Z6NVcsLnEM9AIp8WQ",
+		"hash": "FVRzycWABdtj2I6xDhHsf2aabYU",
 		"delta": 0,
 		"size": 39182
 	},
 	"/convention.html": {
-		"hash": "1Y1GPHzi-FAYYGCpwuuMlucw47Y",
+		"hash": "_A49QzcDTpUWhZf4dBttJxKvIj8",
 		"delta": 0,
 		"size": 21739
 	},
 	"/functional-mocks.html": {
-		"hash": "i_fUZ7OlUhFTxNQGtwODZS7PTHA",
+		"hash": "xLQJtvUqPi1TWYnNTnGb8VFfO6Y",
 		"delta": 0,
 		"size": 29465
 	},
 	"/index.html": {
-		"hash": "ggGDUU4W3PNmkWxSBRvj4MoJEWo",
+		"hash": "6xQBnk2wu9_U0ROQ1xXhsicLFUQ",
 		"delta": 0,
 		"size": 25410
 	},
 	"/installation.html": {
-		"hash": "WF6RyneQgTRxWkvgf0djD-Rrl8E",
+		"hash": "PUi7d-iIiZNNLtEQ3lXcClgxv6E",
 		"delta": 0,
 		"size": 21318
 	},
 	"/motivation.html": {
-		"hash": "bqZ91gHp7UZb4_eiP3LVo56wekE",
+		"hash": "TzjiooP2qIul0i0iAWrRll8cTg8",
 		"delta": 0,
 		"size": 21825
 	},
 	"/plugins.html": {
-		"hash": "GjNAco4roBgiV0hDpfiD5anDZbs",
+		"hash": "Vs7mIFqn75MIYoFfQxQrQFj7hoY",
 		"delta": 0,
 		"size": 24802
 	},
 	"/privacy-and-security.html": {
-		"hash": "X-SvnTbfCwX4eYR4faOL0QgUkPg",
+		"hash": "2Zgz5vRi-XYfXV9Ju9cimwXb5Mc",
 		"delta": 0,
 		"size": 19254
 	},
 	"/scraping.html": {
-		"hash": "atCoMag9atUUB41HLB2uYW3PQ0E",
+		"hash": "iDL6MW1Cu5-9WDzzb3S6A-dtkLc",
 		"delta": 0,
 		"size": 20133
 	}

--- a/www/src/assets/openapi.json
+++ b/www/src/assets/openapi.json
@@ -459,7 +459,7 @@
 		"/mockaton/watch-mocks": {
 			"patch": {
 				"summary": "Enable or disable mock file watching",
-				"description": "Controls file watchers for both mocksDir and staticDir. Pass true to start watching, false to stop. Used primarily in testing when watchers are disabled at startup.",
+				"description": "Controls file watchers for both mocksDir and staticDir.",
 				"x-js-client-example": "await mockaton.setWatchMocks(true)",
 				"requestBody": {
 					"required": true,

--- a/www/src/assets/openapi.json
+++ b/www/src/assets/openapi.json
@@ -456,6 +456,32 @@
 				}
 			}
 		},
+		"/mockaton/watch-mocks": {
+			"patch": {
+				"summary": "Enable or disable mock file watching",
+				"description": "Controls file watchers for both mocksDir and staticDir. Pass true to start watching, false to stop. Used primarily in testing when watchers are disabled at startup.",
+				"x-js-client-example": "await mockaton.setWatchMocks(true)",
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "boolean",
+								"description": "true to start watchers, false to stop them"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"422": {
+						"description": "Invalid input - expected boolean"
+					}
+				}
+			}
+		},
 		"/mockaton/state": {
 			"get": {
 				"summary": "Get complete Mockaton state",


### PR DESCRIPTION
## Summary
Adds a new API endpoint (`/mockaton/watch-mocks`) that allows toggling the mock file watchers on and off at runtime. This gives users control over when Mockaton watches for file changes in `mocksDir` and `staticDir`.

## Changes
- **API endpoint**: Added `PATCH /mockaton/watch-mocks` accepting a boolean to enable/disable watchers
- **Watcher lifecycle**: Implemented `startWatchers()` and `stopWatchers()` functions to manage watcher state
- **Client API**: Added `setWatchMocks(enabled)` method to `ApiCommander`
- **OpenAPI spec**: Documented the new endpoint with request/response schemas
- **Tests**: Added integration tests verifying watchers can be toggled and mocks aren't auto-registered when disabled

## Testing
The test suite verifies that:
- New mock files are not registered when watchers are disabled
- Watchers can be toggled on/off via the API
- Invalid inputs return 422 status codes