### PR TITLE
Handle errors properly in payload viewer preview

### DIFF
--- a/src/client/payload-viewer.js
+++ b/src/client/payload-viewer.js
@@ -84,7 +84,9 @@ export async function previewMock() {
 		if (proxied || file)
 			await updatePayloadViewer(proxied, file, response)
 	}
-	catch {
+	catch (error) {
+		clearTimeout(spinnerTimer)
+		store.onError(error)
 		payloadViewerCodeRef.elem.replaceChildren()
 	}
 }


### PR DESCRIPTION
Improve error handling in the `previewMock` function by capturing the error object and properly cleaning up resources.

## Changes
- Clear spinner timer when errors occur to prevent UI artifacts
- Pass error to store's error handler for proper logging/display
- Previously the catch block was empty, silently swallowing errors