### PR TITLE
Enable logging to stdout/stderr for CLI server

### DIFF
--- a/Ideas.md
+++ b/Ideas.md
@@ -60,9 +60,6 @@ doesn’t break selecting across pages, (e.g., for selecting and copying)
 - Instead of virtual rendering, a simpler progressive chunk attaching, yielding?
 
 
-## Fetch logs
-- API for streaming logs?
-
 ## Browser Extension
 - Dark mode
 

--- a/src/server/Mockaton.test.config.js
+++ b/src/server/Mockaton.test.config.js
@@ -1,10 +1,4 @@
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
-import { mkdtempSync } from 'node:fs'
-
 export default {
-	mocksDir: mkdtempSync(join(tmpdir(), 'mocks')),
-	staticDir: mkdtempSync(join(tmpdir(), 'static')),
 	onReady() {},
 	cookies: {
 		userA: 'CookieA',

--- a/src/server/Mockaton.test.config.js
+++ b/src/server/Mockaton.test.config.js
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtempSync } from 'node:fs'
 
-export const CONFIG = {
+const CONFIG = {
 	mocksDir: mkdtempSync(join(tmpdir(), 'mocks')),
 	staticDir: mkdtempSync(join(tmpdir(), 'static')),
 	onReady() {},
@@ -20,3 +20,6 @@ export const CONFIG = {
 	watcherEnabled: false, // But we enable it at run-time
 	watcherDebounceMs: 0
 }
+
+export { CONFIG }
+export default CONFIG

--- a/src/server/Mockaton.test.config.js
+++ b/src/server/Mockaton.test.config.js
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtempSync } from 'node:fs'
 
-const CONFIG = {
+export default {
 	mocksDir: mkdtempSync(join(tmpdir(), 'mocks')),
 	staticDir: mkdtempSync(join(tmpdir(), 'static')),
 	onReady() {},
@@ -20,6 +20,3 @@ const CONFIG = {
 	watcherEnabled: false, // But we enable it at run-time
 	watcherDebounceMs: 0
 }
-
-export { CONFIG }
-export default CONFIG

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -17,9 +17,6 @@ import { parseFilename } from '../client/Filename.js'
 
 import CONFIG from './Mockaton.test.config.js'
 
-const CLI_PATH = join(import.meta.dirname, 'cli.js')
-const CONFIG_PATH = join(import.meta.dirname, 'Mockaton.test.config.js')
-
 const inMocksDir = f => join(CONFIG.mocksDir, f)
 const inStaticMocksDir = f => join(CONFIG.staticDir, f)
 const readFromMocksDir = f => readFile(inMocksDir(f), 'utf8')
@@ -31,8 +28,8 @@ const renameInStaticMocksDir = (src, target) => rename(inStaticMocksDir(src), in
 const stdout = []
 const stderr = []
 const proc = spawn(process.execPath, [
-	CLI_PATH,
-	'--config', CONFIG_PATH,
+	join(import.meta.dirname, 'cli.js'),
+	'--config', join(import.meta.dirname, 'Mockaton.test.config.js'),
 	'--mocks-dir', CONFIG.mocksDir,
 	'--static-dir', CONFIG.staticDir
 ], {

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -17,9 +17,12 @@ import { API } from '../client/ApiConstants.js'
 import { Commander } from '../client/ApiCommander.js'
 import { parseFilename } from '../client/Filename.js'
 
-import { Mockaton } from './Mockaton.js'
 import { CONFIG } from './Mockaton.test.config.js'
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const CLI_PATH = join(__dirname, 'cli.js')
+const CONFIG_PATH = join(__dirname, 'Mockaton.test.config.js')
 
 const inMocksDir = f => join(CONFIG.mocksDir, f)
 const inStaticMocksDir = f => join(CONFIG.staticDir, f)
@@ -29,10 +32,55 @@ const makeDirInStaticMocks = dir => mkdir(inStaticMocksDir(dir), { recursive: tr
 const renameInMocksDir = (src, target) => rename(inMocksDir(src), inMocksDir(target))
 const renameInStaticMocksDir = (src, target) => rename(inStaticMocksDir(src), inStaticMocksDir(target))
 
-const server = await Mockaton(CONFIG)
-after(() => server?.close())
+// Spawn Mockaton as a subprocess
+let stdout = ''
+let stderr = ''
+const proc = spawn(process.execPath, [
+	CLI_PATH,
+	'--config', CONFIG_PATH,
+	'--mocks-dir', CONFIG.mocksDir,
+	'--static-dir', CONFIG.staticDir
+], {
+	stdio: ['ignore', 'pipe', 'pipe']
+})
 
-const api = new Commander(`http://${server.address().address}:${server.address().port}`)
+proc.stdout.on('data', data => { stdout += data.toString() })
+proc.stderr.on('data', data => { stderr += data.toString() })
+
+// Wait for server to be ready
+await new Promise((resolve, reject) => {
+	const timeout = setTimeout(() => {
+		proc.kill()
+		reject(new Error(`Timeout waiting for server to start. stdout: ${stdout}, stderr: ${stderr}`))
+	}, 5000)
+
+	const checkReady = () => {
+		if (stdout.includes('Listening')) {
+			clearTimeout(timeout)
+			resolve()
+		}
+	}
+
+	proc.stdout.on('data', checkReady)
+	proc.on('error', err => {
+		clearTimeout(timeout)
+		reject(err)
+	})
+})
+
+// Extract server address and port
+const portMatch = stdout.match(/Listening::http:\/\/([^:]+):(\d+)/)
+if (!portMatch) {
+	throw new Error('Could not extract server address from output')
+}
+const serverAddress = portMatch[1]
+const serverPort = parseInt(portMatch[2])
+
+after(() => {
+	proc.kill()
+})
+
+const api = new Commander(`http://${serverAddress}:${serverPort}`)
 
 /** @returns {Promise<State>} */
 async function fetchState() {

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -148,17 +148,13 @@ describe('Rejects malicious URLs', () => {
 describe('Warnings', () => {
 	/**
 	 * Spawns Mockaton as a subprocess and captures its stdio output
-	 * @param {Object} config - Configuration object to pass via config file
-	 * @param {Function} testFn - Async test function that receives { port, output, cleanup }
+	 * @param {Function} testFn - Async test function that receives { port, getOutput }
 	 */
-	async function withSubprocess(config, testFn) {
+	async function withSubprocess(testFn) {
 		const __filename = fileURLToPath(import.meta.url)
 		const __dirname = dirname(__filename)
 		const cliPath = join(__dirname, 'cli.js')
-		const configPath = join(CONFIG.mocksDir, `config-${randomUUID()}.js`)
-
-		// Write config to temp file
-		await writeFile(configPath, `export default ${JSON.stringify(config)}`)
+		const configPath = join(__dirname, 'Mockaton.test.config.js')
 
 		let stdout = ''
 		let stderr = ''
@@ -200,11 +196,10 @@ describe('Warnings', () => {
 		const cleanup = async () => {
 			proc.kill()
 			await new Promise(resolve => proc.on('exit', resolve))
-			await unlink(configPath).catch(() => {})
 		}
 
 		try {
-			await testFn({ port, getOutput: () => ({ stdout, stderr }), cleanup })
+			await testFn({ port, getOutput: () => ({ stdout, stderr }) })
 		} finally {
 			await cleanup()
 		}
@@ -218,7 +213,7 @@ describe('Warnings', () => {
 		await fx1.write()
 		await fx2.write()
 
-		await withSubprocess(CONFIG, async ({ getOutput }) => {
+		await withSubprocess(async ({ getOutput }) => {
 			await new Promise(resolve => setTimeout(resolve, 100))
 			const { stderr } = getOutput()
 
@@ -233,7 +228,7 @@ describe('Warnings', () => {
 	})
 
 	test('body parser rejects invalid JSON in API requests', async t => {
-		await withSubprocess(CONFIG, async ({ port, getOutput }) => {
+		await withSubprocess(async ({ port, getOutput }) => {
 			const api = new Commander(`http://127.0.0.1:${port}`)
 			const r = await fetch(api.addr + API.cookies, {
 				method: 'PATCH',
@@ -249,7 +244,7 @@ describe('Warnings', () => {
 	})
 
 	test('returns 500 when a handler throws', async t => {
-		await withSubprocess(CONFIG, async ({ port, getOutput }) => {
+		await withSubprocess(async ({ port, getOutput }) => {
 			const api = new Commander(`http://127.0.0.1:${port}`)
 			const r = await fetch(api.addr + API.throws)
 			equal(r.status, 500)

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -171,19 +171,21 @@ describe('Warnings', () => {
 		proc.stdout.on('data', data => { stdout += data.toString() })
 		proc.stderr.on('data', data => { stderr += data.toString() })
 
-		// Wait for server to be ready by watching for the "listening" log
+		// Wait for server to be ready by watching for the "Listening" log
 		await new Promise((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				proc.kill()
-				reject(new Error('Timeout waiting for server to start'))
+				reject(new Error(`Timeout waiting for server to start. stdout: ${stdout}, stderr: ${stderr}`))
 			}, 5000)
 
-			proc.stdout.on('data', data => {
-				if (data.toString().includes('listening')) {
+			const checkReady = () => {
+				if (stdout.includes('Listening')) {
 					clearTimeout(timeout)
 					resolve()
 				}
-			})
+			}
+
+			proc.stdout.on('data', checkReady)
 
 			proc.on('error', err => {
 				clearTimeout(timeout)
@@ -191,8 +193,8 @@ describe('Warnings', () => {
 			})
 		})
 
-		// Extract port from output (format: "listening :: http://127.0.0.1:PORT")
-		const portMatch = stdout.match(/listening :: http:\/\/[^:]+:(\d+)/)
+		// Extract port from output (format: "Listening::http://127.0.0.1:PORT")
+		const portMatch = stdout.match(/Listening::http:\/\/[^:]+:(\d+)/)
 		const port = portMatch ? parseInt(portMatch[1]) : null
 
 		const cleanup = async () => {

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -29,7 +29,9 @@ const stdout = []
 const stderr = []
 const proc = spawn(process.execPath, [
 	join(import.meta.dirname, 'cli.js'),
-	'--config', join(import.meta.dirname, 'Mockaton.test.config.js')
+	'--config', join(import.meta.dirname, 'Mockaton.test.config.js'),
+	'--mocks-dir', CONFIG.mocksDir,
+	'--static-dir', CONFIG.staticDir
 ], {
 	stdio: ['ignore', 'pipe', 'pipe']
 })

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -242,7 +242,7 @@ describe('Warnings', () => {
 			})
 			equal(r.status, 422)
 
-			await new Promise(resolve => setTimeout(resolve, 100))
+			await new Promise(resolve => setTimeout(resolve, 200))
 			const { stdout } = getOutput()
 
 			match(stdout, /BodyReaderError: Could not parse/)

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1,4 +1,4 @@
-import { join, dirname } from 'node:path'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { createServer } from 'node:http'
 import { randomUUID } from 'node:crypto'
@@ -6,7 +6,6 @@ import { equal, deepEqual, match } from 'node:assert/strict'
 import { describe, test, before, beforeEach, after } from 'node:test'
 import { writeFile, unlink, mkdir, readFile, rename } from 'node:fs/promises'
 import { spawn } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
 
 import { mimeFor } from './utils/mime.js'
 import { readBody } from './utils/HttpIncomingMessage.js'
@@ -18,10 +17,8 @@ import { parseFilename } from '../client/Filename.js'
 
 import CONFIG from './Mockaton.test.config.js'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const CLI_PATH = join(__dirname, 'cli.js')
-const CONFIG_PATH = join(__dirname, 'Mockaton.test.config.js')
+const CLI_PATH = join(import.meta.dirname, 'cli.js')
+const CONFIG_PATH = join(import.meta.dirname, 'Mockaton.test.config.js')
 
 const inMocksDir = f => join(CONFIG.mocksDir, f)
 const inStaticMocksDir = f => join(CONFIG.staticDir, f)

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -67,19 +67,18 @@ await new Promise((resolve, reject) => {
 	})
 })
 
-// Extract server address and port
-const portMatch = stdout.match(/Listening::http:\/\/([^:]+):(\d+)/)
-if (!portMatch) {
-	throw new Error('Could not extract server address from output')
+// Extract server URL from log output (format: "Listening::http://127.0.0.1:PORT")
+const urlMatch = stdout.match(/Listening::(http:\/\/[^\s\n]+)/)
+if (!urlMatch) {
+	throw new Error('Could not extract server URL from output')
 }
-const serverAddress = portMatch[1]
-const serverPort = parseInt(portMatch[2])
+const serverUrl = urlMatch[1]
 
 after(() => {
 	proc.kill()
 })
 
-const api = new Commander(`http://${serverAddress}:${serverPort}`)
+const api = new Commander(serverUrl)
 
 /** @returns {Promise<State>} */
 async function fetchState() {

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -8,7 +8,6 @@ import { writeFile, unlink, mkdir, readFile, rename } from 'node:fs/promises'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { logger } from './utils/logger.js'
 import { mimeFor } from './utils/mime.js'
 import { readBody } from './utils/HttpIncomingMessage.js'
 import { CorsHeader } from './utils/http-cors.js'

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -32,8 +32,8 @@ const renameInMocksDir = (src, target) => rename(inMocksDir(src), inMocksDir(tar
 const renameInStaticMocksDir = (src, target) => rename(inStaticMocksDir(src), inStaticMocksDir(target))
 
 // Spawn Mockaton as a subprocess
-let stdout = ''
-let stderr = ''
+const stdout = []
+const stderr = []
 const proc = spawn(process.execPath, [
 	CLI_PATH,
 	'--config', CONFIG_PATH,
@@ -43,18 +43,18 @@ const proc = spawn(process.execPath, [
 	stdio: ['ignore', 'pipe', 'pipe']
 })
 
-proc.stdout.on('data', data => { stdout += data.toString() })
-proc.stderr.on('data', data => { stderr += data.toString() })
+proc.stdout.on('data', data => { stdout.push(data.toString()) })
+proc.stderr.on('data', data => { stderr.push(data.toString()) })
 
 // Wait for server to be ready
 await new Promise((resolve, reject) => {
 	const timeout = setTimeout(() => {
 		proc.kill()
-		reject(new Error(`Timeout waiting for server to start. stdout: ${stdout}, stderr: ${stderr}`))
+		reject(new Error(`Timeout waiting for server to start. stdout: ${stdout.join('')}, stderr: ${stderr.join('')}`))
 	}, 5000)
 
 	const checkReady = () => {
-		if (stdout.includes('Listening')) {
+		if (stdout.join('').includes('Listening')) {
 			clearTimeout(timeout)
 			resolve()
 		}
@@ -68,7 +68,7 @@ await new Promise((resolve, reject) => {
 })
 
 // Extract server URL from log output (format: "Listening::http://127.0.0.1:PORT")
-const urlMatch = stdout.match(/Listening::(http:\/\/[^\s\n]+)/)
+const urlMatch = stdout.join('').match(/Listening::(http:\/\/[^\s\n]+)/)
 if (!urlMatch) {
 	throw new Error('Could not extract server URL from output')
 }

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -159,8 +159,14 @@ describe('Warnings', () => {
 		let stdout = ''
 		let stderr = ''
 
-		// Spawn the process
-		const proc = spawn(process.execPath, [cliPath, '--config', configPath], {
+		// Spawn the process with CLI args to override the directories
+		// so the subprocess uses the same directories as the test
+		const proc = spawn(process.execPath, [
+			cliPath,
+			'--config', configPath,
+			'--mocks-dir', CONFIG.mocksDir,
+			'--static-dir', CONFIG.staticDir
+		], {
 			stdio: ['ignore', 'pipe', 'pipe']
 		})
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -31,7 +31,6 @@ const makeDirInStaticMocks = dir => mkdir(inStaticMocksDir(dir), { recursive: tr
 const renameInMocksDir = (src, target) => rename(inMocksDir(src), inMocksDir(target))
 const renameInStaticMocksDir = (src, target) => rename(inStaticMocksDir(src), inStaticMocksDir(target))
 
-// Spawn Mockaton as a subprocess
 const stdout = []
 const stderr = []
 const proc = spawn(process.execPath, [
@@ -46,7 +45,6 @@ const proc = spawn(process.execPath, [
 proc.stdout.on('data', data => { stdout.push(data.toString()) })
 proc.stderr.on('data', data => { stderr.push(data.toString()) })
 
-// Wait for server to be ready
 await new Promise((resolve, reject) => {
 	const timeout = setTimeout(() => {
 		proc.kill()
@@ -67,7 +65,6 @@ await new Promise((resolve, reject) => {
 	})
 })
 
-// Extract server URL from log output (format: "Listening::http://127.0.0.1:PORT")
 const urlMatch = stdout.join('').match(/Listening::(http:\/\/[^\s\n]+)/)
 if (!urlMatch) {
 	throw new Error('Could not extract server URL from output')

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1,10 +1,12 @@
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import { promisify } from 'node:util'
 import { createServer } from 'node:http'
 import { randomUUID } from 'node:crypto'
 import { equal, deepEqual, match } from 'node:assert/strict'
 import { describe, test, before, beforeEach, after } from 'node:test'
 import { writeFile, unlink, mkdir, readFile, rename } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 import { logger } from './utils/logger.js'
 import { mimeFor } from './utils/mime.js'

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -32,8 +32,7 @@ const renameInStaticMocksDir = (src, target) => rename(inStaticMocksDir(src), in
 
 const stdout = []
 const stderr = []
-const proc = spawn(process.execPath, [
-	join(import.meta.dirname, 'cli.js'),
+const proc = spawn(join(import.meta.dirname, 'cli.js'), [
 	'--config', join(import.meta.dirname, 'Mockaton.test.config.js'),
 	'--mocks-dir', mocksDir,
 	'--static-dir', staticDir

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -29,9 +29,7 @@ const stdout = []
 const stderr = []
 const proc = spawn(process.execPath, [
 	join(import.meta.dirname, 'cli.js'),
-	'--config', join(import.meta.dirname, 'Mockaton.test.config.js'),
-	'--mocks-dir', CONFIG.mocksDir,
-	'--static-dir', CONFIG.staticDir
+	'--config', join(import.meta.dirname, 'Mockaton.test.config.js')
 ], {
 	stdio: ['ignore', 'pipe', 'pipe']
 })

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -201,9 +201,9 @@ describe('Warnings', () => {
 		await fx2.write()
 		await api.reset()
 
-		match(stderr, /Invalid HTTP Response Status: "NaN"/)
-		match(stderr, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
-		match(stderr, /Invalid Filename Convention/)
+		match(stderr.at(-1), /Invalid HTTP Response Status: "NaN"/)
+		match(stderr.at(-1), /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
+		match(stderr.at(-1), /Invalid Filename Convention/)
 
 		await fx0.unlink()
 		await fx1.unlink()
@@ -216,13 +216,13 @@ describe('Warnings', () => {
 			body: '[invalid_json]'
 		})
 		equal(r.status, 422)
-		match(stdout, /BodyReaderError: Could not parse/)
+		match(stdout.at(-1), /BodyReaderError: Could not parse/)
 	})
 
 	test('returns 500 when a handler throws', async t => {
 		const r = await request(API.throws)
 		equal(r.status, 500)
-		match(stderr, /Test500/)
+		match(stderr.at(-1), /Test500/)
 	})
 })
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -1,11 +1,13 @@
 import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { tmpdir } from 'node:os'
 import { promisify } from 'node:util'
 import { createServer } from 'node:http'
+import { mkdtempSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { equal, deepEqual, match } from 'node:assert/strict'
 import { describe, test, before, beforeEach, after } from 'node:test'
 import { writeFile, unlink, mkdir, readFile, rename } from 'node:fs/promises'
-import { spawn } from 'node:child_process'
 
 import { mimeFor } from './utils/mime.js'
 import { readBody } from './utils/HttpIncomingMessage.js'
@@ -17,8 +19,11 @@ import { parseFilename } from '../client/Filename.js'
 
 import CONFIG from './Mockaton.test.config.js'
 
-const inMocksDir = f => join(CONFIG.mocksDir, f)
-const inStaticMocksDir = f => join(CONFIG.staticDir, f)
+const mocksDir = mkdtempSync(join(tmpdir(), 'mocks'))
+const staticDir = mkdtempSync(join(tmpdir(), 'static'))
+
+const inMocksDir = f => join(mocksDir, f)
+const inStaticMocksDir = f => join(staticDir, f)
 const readFromMocksDir = f => readFile(inMocksDir(f), 'utf8')
 const makeDirInMocks = dir => mkdir(inMocksDir(dir), { recursive: true })
 const makeDirInStaticMocks = dir => mkdir(inStaticMocksDir(dir), { recursive: true })
@@ -30,46 +35,25 @@ const stderr = []
 const proc = spawn(process.execPath, [
 	join(import.meta.dirname, 'cli.js'),
 	'--config', join(import.meta.dirname, 'Mockaton.test.config.js'),
-	'--mocks-dir', CONFIG.mocksDir,
-	'--static-dir', CONFIG.staticDir
-], {
-	stdio: ['ignore', 'pipe', 'pipe']
-})
+	'--mocks-dir', mocksDir,
+	'--static-dir', staticDir
+])
 
 proc.stdout.on('data', data => { stdout.push(data.toString()) })
 proc.stderr.on('data', data => { stderr.push(data.toString()) })
 
-await new Promise((resolve, reject) => {
-	const timeout = setTimeout(() => {
-		proc.kill()
-		reject(new Error(`Timeout waiting for server to start. stdout: ${stdout.join('')}, stderr: ${stderr.join('')}`))
-	}, 5000)
-
-	const checkReady = () => {
-		if (stdout.join('').includes('Listening')) {
-			clearTimeout(timeout)
-			resolve()
-		}
-	}
-
-	proc.stdout.on('data', checkReady)
-	proc.on('error', err => {
-		clearTimeout(timeout)
-		reject(err)
+const serverAddr = await new Promise((resolve, reject) => {
+	proc.stdout.on('data', () => {
+		const addr = stdout[0].match(/Listening::(http:\/\/[^\s\n]+)/)[1]
+		if (addr)
+			resolve(addr)
 	})
+	proc.on('error', reject)
 })
 
-const urlMatch = stdout.join('').match(/Listening::(http:\/\/[^\s\n]+)/)
-if (!urlMatch) {
-	throw new Error('Could not extract server URL from output')
-}
-const serverUrl = urlMatch[1]
+after(() => proc.kill())
 
-after(() => {
-	proc.kill()
-})
-
-const api = new Commander(serverUrl)
+const api = new Commander(serverAddr)
 
 /** @returns {Promise<State>} */
 async function fetchState() {
@@ -128,7 +112,7 @@ class BaseFixture {
 class Fixture extends BaseFixture {
 	constructor(file, body = '') {
 		super(file, body)
-		this.dir = CONFIG.mocksDir
+		this.dir = mocksDir
 		const t = parseFilename(file)
 		this.urlMask = t.urlMask
 		this.method = t.method
@@ -143,7 +127,7 @@ class Fixture extends BaseFixture {
 class FixtureStatic extends BaseFixture {
 	constructor(file, body = '') {
 		super(file, body)
-		this.dir = CONFIG.staticDir
+		this.dir = staticDir
 		this.urlMask = '/' + file
 		this.method = 'GET'
 	}
@@ -192,8 +176,8 @@ describe('Warnings', () => {
 		await fx2.write()
 		await api.reset()
 
-		match(stderr.at(-1), /Invalid HTTP Response Status: "NaN"/)
-		match(stderr.at(-1), /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
+		match(stderr.at(-3), /Invalid HTTP Response Status: "NaN"/)
+		match(stderr.at(-2), /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
 		match(stderr.at(-1), /Invalid Filename Convention/)
 
 		await fx0.unlink()

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -194,71 +194,6 @@ describe('Rejects malicious URLs', () => {
 
 
 describe('Warnings', () => {
-	/**
-	 * Spawns Mockaton as a subprocess and captures its stdio output
-	 * @param {Function} testFn - Async test function that receives { port, getOutput }
-	 */
-	async function withSubprocess(testFn) {
-		const __filename = fileURLToPath(import.meta.url)
-		const __dirname = dirname(__filename)
-		const cliPath = join(__dirname, 'cli.js')
-		const configPath = join(__dirname, 'Mockaton.test.config.js')
-
-		let stdout = ''
-		let stderr = ''
-
-		// Spawn the process with CLI args to override the directories
-		// so the subprocess uses the same directories as the test
-		const proc = spawn(process.execPath, [
-			cliPath,
-			'--config', configPath,
-			'--mocks-dir', CONFIG.mocksDir,
-			'--static-dir', CONFIG.staticDir
-		], {
-			stdio: ['ignore', 'pipe', 'pipe']
-		})
-
-		proc.stdout.on('data', data => { stdout += data.toString() })
-		proc.stderr.on('data', data => { stderr += data.toString() })
-
-		// Wait for server to be ready by watching for the "Listening" log
-		await new Promise((resolve, reject) => {
-			const timeout = setTimeout(() => {
-				proc.kill()
-				reject(new Error(`Timeout waiting for server to start. stdout: ${stdout}, stderr: ${stderr}`))
-			}, 5000)
-
-			const checkReady = () => {
-				if (stdout.includes('Listening')) {
-					clearTimeout(timeout)
-					resolve()
-				}
-			}
-
-			proc.stdout.on('data', checkReady)
-
-			proc.on('error', err => {
-				clearTimeout(timeout)
-				reject(err)
-			})
-		})
-
-		// Extract port from output (format: "Listening::http://127.0.0.1:PORT")
-		const portMatch = stdout.match(/Listening::http:\/\/[^:]+:(\d+)/)
-		const port = portMatch ? parseInt(portMatch[1]) : null
-
-		const cleanup = async () => {
-			proc.kill()
-			await new Promise(resolve => proc.on('exit', resolve))
-		}
-
-		try {
-			await testFn({ port, getOutput: () => ({ stdout, stderr }) })
-		} finally {
-			await cleanup()
-		}
-	}
-
 	test('rejects invalid filenames', async t => {
 		const fx0 = new Fixture('bar.GET._INVALID_STATUS_.json')
 		const fx1 = new Fixture('foo._INVALID_METHOD_.202.json')
@@ -267,14 +202,13 @@ describe('Warnings', () => {
 		await fx1.write()
 		await fx2.write()
 
-		await withSubprocess(async ({ getOutput }) => {
-			await new Promise(resolve => setTimeout(resolve, 100))
-			const { stderr } = getOutput()
+		// Reset to trigger file scanning
+		await api.reset()
+		await new Promise(resolve => setTimeout(resolve, 100))
 
-			match(stderr, /Invalid HTTP Response Status: "NaN"/)
-			match(stderr, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
-			match(stderr, /Invalid Filename Convention/)
-		})
+		match(stderr, /Invalid HTTP Response Status: "NaN"/)
+		match(stderr, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
+		match(stderr, /Invalid Filename Convention/)
 
 		await fx0.unlink()
 		await fx1.unlink()
@@ -282,32 +216,24 @@ describe('Warnings', () => {
 	})
 
 	test('body parser rejects invalid JSON in API requests', async t => {
-		await withSubprocess(async ({ port, getOutput }) => {
-			const api = new Commander(`http://127.0.0.1:${port}`)
-			const r = await fetch(api.addr + API.cookies, {
-				method: 'PATCH',
-				body: '[invalid_json]'
-			})
-			equal(r.status, 422)
-
-			await new Promise(resolve => setTimeout(resolve, 200))
-			const { stdout } = getOutput()
-
-			match(stdout, /BodyReaderError: Could not parse/)
+		const r = await fetch(api.addr + API.cookies, {
+			method: 'PATCH',
+			body: '[invalid_json]'
 		})
+		equal(r.status, 422)
+
+		await new Promise(resolve => setTimeout(resolve, 100))
+
+		match(stdout, /BodyReaderError: Could not parse/)
 	})
 
 	test('returns 500 when a handler throws', async t => {
-		await withSubprocess(async ({ port, getOutput }) => {
-			const api = new Commander(`http://127.0.0.1:${port}`)
-			const r = await fetch(api.addr + API.throws)
-			equal(r.status, 500)
+		const r = await fetch(api.addr + API.throws)
+		equal(r.status, 500)
 
-			await new Promise(resolve => setTimeout(resolve, 100))
-			const { stderr } = getOutput()
+		await new Promise(resolve => setTimeout(resolve, 100))
 
-			match(stderr, /Test500/)
-		})
+		match(stderr, /Test500/)
 	})
 })
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -176,9 +176,10 @@ describe('Warnings', () => {
 		await fx2.write()
 		await api.reset()
 
-		match(stderr.at(-3), /Invalid HTTP Response Status: "NaN"/)
-		match(stderr.at(-2), /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
-		match(stderr.at(-1), /Invalid Filename Convention/)
+		const log = stderr.join('')
+		match(log, /Invalid HTTP Response Status: "NaN"/)
+		match(log, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
+		match(log, /Invalid Filename Convention/)
 
 		await fx0.unlink()
 		await fx1.unlink()

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -199,10 +199,7 @@ describe('Warnings', () => {
 		await fx0.write()
 		await fx1.write()
 		await fx2.write()
-
-		// Reset to trigger file scanning
 		await api.reset()
-		await new Promise(resolve => setTimeout(resolve, 100))
 
 		match(stderr, /Invalid HTTP Response Status: "NaN"/)
 		match(stderr, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
@@ -214,23 +211,17 @@ describe('Warnings', () => {
 	})
 
 	test('body parser rejects invalid JSON in API requests', async t => {
-		const r = await fetch(api.addr + API.cookies, {
+		const r = await request(API.cookies, {
 			method: 'PATCH',
 			body: '[invalid_json]'
 		})
 		equal(r.status, 422)
-
-		await new Promise(resolve => setTimeout(resolve, 100))
-
 		match(stdout, /BodyReaderError: Could not parse/)
 	})
 
 	test('returns 500 when a handler throws', async t => {
-		const r = await fetch(api.addr + API.throws)
+		const r = await request(API.throws)
 		equal(r.status, 500)
-
-		await new Promise(resolve => setTimeout(resolve, 100))
-
 		match(stderr, /Test500/)
 	})
 })

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -146,25 +146,84 @@ describe('Rejects malicious URLs', () => {
 
 
 describe('Warnings', () => {
-	function spyLogger(t, method) {
-		const spy = t.mock.method(logger, method)
-		spy.mock.mockImplementation(() => null)
-		return spy.mock
+	/**
+	 * Spawns Mockaton as a subprocess and captures its stdio output
+	 * @param {Object} config - Configuration object to pass via config file
+	 * @param {Function} testFn - Async test function that receives { port, output, cleanup }
+	 */
+	async function withSubprocess(config, testFn) {
+		const __filename = fileURLToPath(import.meta.url)
+		const __dirname = dirname(__filename)
+		const cliPath = join(__dirname, 'cli.js')
+		const configPath = join(CONFIG.mocksDir, `config-${randomUUID()}.js`)
+
+		// Write config to temp file
+		await writeFile(configPath, `export default ${JSON.stringify(config)}`)
+
+		let stdout = ''
+		let stderr = ''
+
+		// Spawn the process
+		const proc = spawn(process.execPath, [cliPath, '--config', configPath], {
+			stdio: ['ignore', 'pipe', 'pipe']
+		})
+
+		proc.stdout.on('data', data => { stdout += data.toString() })
+		proc.stderr.on('data', data => { stderr += data.toString() })
+
+		// Wait for server to be ready by watching for the "listening" log
+		await new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				proc.kill()
+				reject(new Error('Timeout waiting for server to start'))
+			}, 5000)
+
+			proc.stdout.on('data', data => {
+				if (data.toString().includes('listening')) {
+					clearTimeout(timeout)
+					resolve()
+				}
+			})
+
+			proc.on('error', err => {
+				clearTimeout(timeout)
+				reject(err)
+			})
+		})
+
+		// Extract port from output (format: "listening :: http://127.0.0.1:PORT")
+		const portMatch = stdout.match(/listening :: http:\/\/[^:]+:(\d+)/)
+		const port = portMatch ? parseInt(portMatch[1]) : null
+
+		const cleanup = async () => {
+			proc.kill()
+			await new Promise(resolve => proc.on('exit', resolve))
+			await unlink(configPath).catch(() => {})
+		}
+
+		try {
+			await testFn({ port, getOutput: () => ({ stdout, stderr }), cleanup })
+		} finally {
+			await cleanup()
+		}
 	}
 
 	test('rejects invalid filenames', async t => {
-		const spy = spyLogger(t, 'warn')
 		const fx0 = new Fixture('bar.GET._INVALID_STATUS_.json')
 		const fx1 = new Fixture('foo._INVALID_METHOD_.202.json')
 		const fx2 = new Fixture('missing-method-and-status.json')
 		await fx0.write()
 		await fx1.write()
 		await fx2.write()
-		await api.reset()
 
-		equal(spy.calls[0].arguments[0], 'Invalid HTTP Response Status: "NaN"')
-		equal(spy.calls[1].arguments[0], 'Unrecognized HTTP Method: "_INVALID_METHOD_"')
-		equal(spy.calls[2].arguments[0], 'Invalid Filename Convention')
+		await withSubprocess(CONFIG, async ({ getOutput }) => {
+			await new Promise(resolve => setTimeout(resolve, 100))
+			const { stderr } = getOutput()
+
+			match(stderr, /Invalid HTTP Response Status: "NaN"/)
+			match(stderr, /Unrecognized HTTP Method: "_INVALID_METHOD_"/)
+			match(stderr, /Invalid Filename Convention/)
+		})
 
 		await fx0.unlink()
 		await fx1.unlink()
@@ -172,20 +231,32 @@ describe('Warnings', () => {
 	})
 
 	test('body parser rejects invalid JSON in API requests', async t => {
-		const spy = spyLogger(t, 'access')
-		const r = await request(API.cookies, {
-			method: 'PATCH',
-			body: '[invalid_json]'
+		await withSubprocess(CONFIG, async ({ port, getOutput }) => {
+			const api = new Commander(`http://127.0.0.1:${port}`)
+			const r = await fetch(api.addr + API.cookies, {
+				method: 'PATCH',
+				body: '[invalid_json]'
+			})
+			equal(r.status, 422)
+
+			await new Promise(resolve => setTimeout(resolve, 100))
+			const { stdout } = getOutput()
+
+			match(stdout, /BodyReaderError: Could not parse/)
 		})
-		equal(r.status, 422)
-		equal(spy.calls[0].arguments[1], 'BodyReaderError: Could not parse')
 	})
 
 	test('returns 500 when a handler throws', async t => {
-		const spy = spyLogger(t, 'error')
-		const r = await request(API.throws)
-		equal(r.status, 500)
-		equal(spy.calls[0].arguments[2], 'Test500')
+		await withSubprocess(CONFIG, async ({ port, getOutput }) => {
+			const api = new Commander(`http://127.0.0.1:${port}`)
+			const r = await fetch(api.addr + API.throws)
+			equal(r.status, 500)
+
+			await new Promise(resolve => setTimeout(resolve, 100))
+			const { stderr } = getOutput()
+
+			match(stderr, /Test500/)
+		})
 	})
 })
 

--- a/src/server/Mockaton.test.js
+++ b/src/server/Mockaton.test.js
@@ -16,7 +16,7 @@ import { API } from '../client/ApiConstants.js'
 import { Commander } from '../client/ApiCommander.js'
 import { parseFilename } from '../client/Filename.js'
 
-import { CONFIG } from './Mockaton.test.config.js'
+import CONFIG from './Mockaton.test.config.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)


### PR DESCRIPTION
Spawn CLI server as child process and capture stdout/stderr for test assertions instead of mocking `console.log,info,error`